### PR TITLE
Added /document input log and duplicated maxRequestSize size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
 ### Fixed
 - Github template tests fail in proxy environment ([#56](https://github.com/opendevstack/ods-document-generation-svc/issues/56))
 
+## [4.0] - 2021-15-11
+
+### Added
+- Added log to print /document endpoint input
+
+### Changed
+- Updated maxRequestSize value from 100m to 200m
+
 ## [3.0] - 2020-08-11
 
 ### Added
@@ -27,3 +35,4 @@
 - Doc gen Service jenkins lacks Sonarqube config / scan ([#17](https://github.com/opendevstack/ods-document-generation-svc/issues/17))
 - fix yml to adopt for quickstarter ([#22](https://github.com/opendevstack/ods-document-generation-svc/pull/22))
 - Using HTML headers and footers causes large documents to fail ([#9](https://github.com/opendevstack/ods-document-generation-svc/issues/9))
+

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -11,9 +11,9 @@ application {
 }
 
 server {
-    maxRequestSize = 100m
+    maxRequestSize = 200m
 
     http {
-        MaxRequestSize = 100m
+        MaxRequestSize = 200m
     }
 }

--- a/src/main/groovy/app/App.groovy
+++ b/src/main/groovy/app/App.groovy
@@ -1,18 +1,18 @@
 package app
 
 import com.typesafe.config.ConfigFactory
-
 import groovy.json.JsonSlurper
-
-import java.nio.file.Files
-
+import groovy.util.logging.Slf4j
 import org.jooby.Jooby
 import org.jooby.MediaType
 import org.jooby.json.Jackson
 
+import java.nio.file.Files
+
 import static org.jooby.JoobyExtension.get
 import static org.jooby.JoobyExtension.post
 
+@Slf4j
 class App extends Jooby {
 
     {
@@ -21,6 +21,12 @@ class App extends Jooby {
 
         post(this, "/document", { req, rsp ->
             def body = new JsonSlurper().parseText(req.body().value())
+
+            if (log.isInfoEnabled()) {
+                log.info("Input request body before send it to convert it to a pdf: ");
+                log.info(body.toString());
+            }
+
             validateRequestParams(body)
 
             def pdf = new DocGen().generate(body.metadata.type, body.metadata.version, body.data)


### PR DESCRIPTION
- Added info log to print input in /document endpoint
- Increased maxRequestSize from 100m to 200m