### PR TITLE
Solves GitHub pipelines actions problems. 

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -38,25 +38,26 @@ jobs:
     - name: copy created artifacts into docker context
       run: | 
         cp build/libs/*-all.jar ./docker/app.jar
-    - name: Show GitHub context
+    - name: Show GitHub context (for debugging purposes)
       env:
         GITHUB_CONTEXT: ${{ toJson(github) }}
       run: echo "$GITHUB_CONTEXT"
     - name: Build docker image
       if: success()
       run: |
-        echo "HEAD_SHA: ${{ github.event.pull_request.head.sha }}"
-        echo "GITHUB_SHA: $GITHUB_SHA "
-        COMMIT_AUTHOR=$(git --no-pager show -s --format='%an (%ae)' $GITHUB_SHA)
-        COMMIT_MESSAGE=$(git log -1 --pretty=%B $GITHUB_SHA)
-        COMMIT_TIME=$(git show -s --format=%ci $GITHUB_SHA)
+        echo "GITHUB_SHA (invalid): $GITHUB_SHA "
+        COMMIT_HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+        echo "COMMIT_HEAD_SHA: $COMMIT_HEAD_SHA"
+        COMMIT_AUTHOR=$(git --no-pager show -s --format='%an (%ae)' $COMMIT_HEAD_SHA)
+        COMMIT_MESSAGE=$(git log -1 --pretty=%B $COMMIT_HEAD_SHA)
+        COMMIT_TIME=$(git show -s --format=%ci $COMMIT_HEAD_SHA)
         BUILD_TIME=$(date -u "+%Y-%m-%d %H:%M:%S %z")
         docker build \
         --label "ods.build.job.url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
         --label "ods.build.source.repo.ref=$GITHUB_REF" \
         --label "ods.build.source.repo.commit.author=$COMMIT_AUTHOR" \
         --label "ods.build.source.repo.commit.msg=$COMMIT_MESSAGE" \
-        --label "ods.build.source.repo.commit.sha=$GITHUB_SHA" \
+        --label "ods.build.source.repo.commit.sha=$COMMIT_HEAD_SHA" \
         --label "ods.build.source.repo.commit.timestamp=$COMMIT_TIME" \
         --label "ods.build.source.repo.url=https://github.com/$GITHUB_REPOSITORY.git" \
         --label "ods.build.timestamp=$BUILD_TIME" \

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -41,6 +41,8 @@ jobs:
     - name: Build docker image
       if: success()
       run: |
+        echo "HEAD_SHA: ${{ github.event.pull_request.head.sha }}"
+        echo "GITHUB_SHA: $GITHUB_SHA "
         COMMIT_AUTHOR=$(git --no-pager show -s --format='%an (%ae)' $GITHUB_SHA)
         COMMIT_MESSAGE=$(git log -1 --pretty=%B $GITHUB_SHA)
         COMMIT_TIME=$(git show -s --format=%ci $GITHUB_SHA)

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -38,6 +38,10 @@ jobs:
     - name: copy created artifacts into docker context
       run: | 
         cp build/libs/*-all.jar ./docker/app.jar
+    - name: Show GitHub context
+      env:
+        GITHUB_CONTEXT: ${{ toJson(github) }}
+      run: echo "$GITHUB_CONTEXT"
     - name: Build docker image
       if: success()
       run: |


### PR DESCRIPTION
There is a problem getting the SHA in a PR:
https://stackoverflow.com/questions/68061051/get-commit-sha-in-github-actions

When you can create a pull request, github will execute workflow based on a fake merge branch: refs/pull/:prNumber/merge, the merge_commit_sha doesn’t exist on base or head branch, but points to that surrogate merge commit, and there is a mergeable key to show the status of the test commit.


